### PR TITLE
Added VimRegStyle dependency to README

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -6,6 +6,7 @@ __Enhanced editing support for http://asciidoc.org[Asciidoc] files in Vim__
 
 * https://github.com/dahu/vimple[]
 * https://github.com/dahu/Asif[]
+* https://github.com/Raimondi/VimRegStyle[]
 * (optional) https://github.com/vim-scripts/SyntaxRange[]
 
 === Compilers


### PR DESCRIPTION
Added the VimRegStyle dependency to the README. ERex.parse is used for list_pattern in the ftplugin.